### PR TITLE
Update go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ApsieSoft/go-regex
+module github.com/AspieSoft/go-regex
 
 go 1.13
 


### PR DESCRIPTION
fixing module name to allow using your module

$ go get github.com/AspieSoft/go-regex
go: github.com/AspieSoft/go-regex@v1.2.1: parsing go.mod:
	module declares its path as: github.com/ApsieSoft/go-regex
	        but was required as: github.com/AspieSoft/go-regex